### PR TITLE
Dev/mar bi/93 bug in nav component

### DIFF
--- a/src/layouts/components/Header.js
+++ b/src/layouts/components/Header.js
@@ -26,6 +26,9 @@ const BrandLink = styled(Link)`
   &:active {
     color: inherit;
   }
+  &:hover {
+    color: ${CP.secondary.red};
+  }
 `
 
 const Header = () => (

--- a/src/layouts/components/PageNav.js
+++ b/src/layouts/components/PageNav.js
@@ -30,6 +30,7 @@ const NavLink = styled(Link).attrs({
   }
   &:hover {
     color: ${props => props.color}
+  }
 `
 
 const PageNav = props => (
@@ -40,7 +41,9 @@ const PageNav = props => (
       </NavLink>
     </NavItem>
     <NavItem data-header={props.header}>
-      <NavLink to="/learn">learn</NavLink>
+      <NavLink to="/learn" data-header={props.header}>
+        learn
+      </NavLink>
     </NavItem>
     <NavItem data-header={props.header}>
       <NavLink to="/events" data-header={props.header}>

--- a/src/layouts/components/PageNav.js
+++ b/src/layouts/components/PageNav.js
@@ -25,11 +25,12 @@ const NavLink = styled(Link).attrs({
   color: props => (props['data-header'] ? CP.secondary.red : CP.secondary.green)
 })`
   color: inherit;
-  &:visited, &:active {
-     color: inherit;
+  &:visited,
+  &:active {
+    color: inherit;
   }
   &:hover {
-    color: ${props => props.color}
+    color: ${props => props.color};
   }
 `
 


### PR DESCRIPTION
The hover color of `LEARN` link in `Header` had different color.
**Problem**: missed `data-header` attribute for this link. (solved)

**Additional feature**: add **red** hover color for `brand name` in `Header`. Now all `Header` has the same hover style.

closes #93