### PR TITLE
Dev/mar bi/168 responsive cards

### DIFF
--- a/src/layouts/components/CardContainer.js
+++ b/src/layouts/components/CardContainer.js
@@ -27,7 +27,9 @@ const StyledStories = styled.div`
   border-radius: 2px;
   padding: 0.6rem;
   & > div:last-child {
-    display: ${props => (props.cols < props.cards)? `none` : `flex`};
+    display: ${props => (props.cols < props.cards)?
+      `none`:
+      (props.story? `grid` : `flex`)};
   }
   ${media.desktop`
     grid-column: 1 / span 12;
@@ -37,22 +39,41 @@ const StyledStories = styled.div`
     margin: 0.5rem 2rem;
     grid-template-columns: ${props => (props.cols > 3)? `repeat(${Math.floor(props.cols / 2)}, 1fr)`: `repeat(${props.cols}, 1fr)`};
     & > div:last-child {
-      display: flex;
+      display: ${props => props.story? `grid` : `flex`};
     }
   `}
   ${media.phone`
-    margin: 0.5rem;
+    margin: 0;
     grid-column: 2 / span 10;
     grid-template-columns: repeat(1, 1fr);
     grid-gap: 1rem;
   `}
 `
+// basic layout (in StyledStories)
+// n = props.cols
+// - n cards on all big screens
+// - Math.floor( n / 2) on a tablet screen
+// - 1 column on a phone screen
+
+// example: n = 5
+// 5 cards / 2 cards / 1 card
+
+// if n <= 3
+// - n cards on big screens & tablets
+// - 1 column on the phone screen
+
+// we can supply 6 cards for 5 columns via
+// props.cards = 6 and props.col = 5
+// result:
+// 5 columns / 5 cards - 2 columns / 6 cards - 1 column / 6 cards
+
 
 const CardContainer = props => (
   <StyledCardContainer>
     <StyledStories
       cols={props.cols}
       cards={props.cards}
+      story={props.story}
     >
       {props.children}
     </StyledStories>
@@ -62,6 +83,7 @@ const CardContainer = props => (
 CardContainer.propTypes = {
   cols: PropTypes.number.isRequired, //number of columns
   cards: PropTypes.number, // number of cards
+  story: PropTypes.bool,
   children: PropTypes.array
 }
 

--- a/src/layouts/components/CardContainer.js
+++ b/src/layouts/components/CardContainer.js
@@ -2,31 +2,66 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
+import { media } from '../../theme/globalStyle'
+
 const StyledCardContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   grid-template-rows: auto;
   margin: 1.5rem 0 3rem 0;
+  ${media.desktop`
+    margin: 0;
+  `}
+  ${media.phone`
+    margin: 0.5rem 0 1rem 0;
+  `}
 `
 
 const StyledStories = styled.div`
-  grid-column: 3 / span 8;
+  grid-column: 2 / span 10;
   display: grid;
   grid-template-columns: ${props => `repeat(${props.cols}, 1fr)`};
   grid-template-rows: auto;
   grid-gap: 0.5rem;
   border: 2px solid ${props => props.theme.primary.dark};
-  padding: 1rem;
+  border-radius: 2px;
+  padding: 0.6rem;
+  & > div:last-child {
+    display: ${props => (props.cols < props.cards)? `none` : `flex`};
+  }
+  ${media.desktop`
+    grid-column: 1 / span 12;
+    margin: 0 1.5rem;
+  `}
+  ${media.tablet`
+    margin: 0.5rem 2rem;
+    grid-template-columns: ${props => (props.cols > 3)? `repeat(${Math.floor(props.cols / 2)}, 1fr)`: `repeat(${props.cols}, 1fr)`};
+    & > div:last-child {
+      display: flex;
+    }
+  `}
+  ${media.phone`
+    margin: 0.5rem;
+    grid-column: 2 / span 10;
+    grid-template-columns: repeat(1, 1fr);
+    grid-gap: 1rem;
+  `}
 `
 
 const CardContainer = props => (
   <StyledCardContainer>
-    <StyledStories cols={props.cols}>{props.children}</StyledStories>
+    <StyledStories
+      cols={props.cols}
+      cards={props.cards}
+    >
+      {props.children}
+    </StyledStories>
   </StyledCardContainer>
 )
 
 CardContainer.propTypes = {
-  cols: PropTypes.number.isRequired,
+  cols: PropTypes.number.isRequired, //number of columns
+  cards: PropTypes.number, // number of cards
   children: PropTypes.array
 }
 

--- a/src/layouts/components/CardContainer.js
+++ b/src/layouts/components/CardContainer.js
@@ -11,10 +11,9 @@ const StyledCardContainer = styled.div`
   margin: 1.5rem 0 3rem 0;
   ${media.desktop`
     margin: 0;
-  `}
-  ${media.phone`
+  `} ${media.phone`
     margin: 0.5rem 0 1rem 0;
-  `}
+  `};
 `
 
 const StyledStories = styled.div`
@@ -27,27 +26,27 @@ const StyledStories = styled.div`
   border-radius: 2px;
   padding: 0.6rem;
   & > div:last-child {
-    display: ${props => (props.cols < props.cards)?
-      `none`:
-      (props.story? `grid` : `flex`)};
+    display: ${props =>
+      props.cols < props.cards ? 'none' : props.story ? 'grid' : 'flex'};
   }
   ${media.desktop`
     grid-column: 1 / span 12;
     margin: 0 1.5rem;
-  `}
-  ${media.tablet`
+  `} ${media.tablet`
     margin: 0.5rem 2rem;
-    grid-template-columns: ${props => (props.cols > 3)? `repeat(${Math.floor(props.cols / 2)}, 1fr)`: `repeat(${props.cols}, 1fr)`};
+    grid-template-columns: ${props =>
+      props.cols > 3
+        ? `repeat(${Math.floor(props.cols / 2)}, 1fr)`
+        : `repeat(${props.cols}, 1fr)`};
     & > div:last-child {
-      display: ${props => props.story? `grid` : `flex`};
+      display: ${props => (props.story ? 'grid' : 'flex')};
     }
-  `}
-  ${media.phone`
+  `} ${media.phone`
     margin: 0;
     grid-column: 2 / span 10;
     grid-template-columns: repeat(1, 1fr);
     grid-gap: 1rem;
-  `}
+  `};
 `
 // basic layout (in StyledStories)
 // n = props.cols
@@ -67,14 +66,9 @@ const StyledStories = styled.div`
 // result:
 // 5 columns / 5 cards - 2 columns / 6 cards - 1 column / 6 cards
 
-
 const CardContainer = props => (
   <StyledCardContainer>
-    <StyledStories
-      cols={props.cols}
-      cards={props.cards}
-      story={props.story}
-    >
+    <StyledStories cols={props.cols} cards={props.cards} story={props.story}>
       {props.children}
     </StyledStories>
   </StyledCardContainer>

--- a/src/layouts/components/CoursesContainer.js
+++ b/src/layouts/components/CoursesContainer.js
@@ -47,7 +47,7 @@ class CoursesContainer extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      menuFilter: ['all', 'new', 'popular'],
+      menuFilter: ['all', 'new', 'courses', 'interviews'],
       searchQuery: '',
       query: [
         {

--- a/src/layouts/components/Divider.js
+++ b/src/layouts/components/Divider.js
@@ -22,6 +22,10 @@ const Wrapper = styled.div`
   ${media.desktop`
     padding: 0.5em;
   `};
+  ${media.phone`
+    margin-top: 2.5rem;
+  `}
+
 `
 Wrapper.propTypes = {
   set: PropTypes.string.isRequired

--- a/src/layouts/components/Divider.js
+++ b/src/layouts/components/Divider.js
@@ -25,8 +25,7 @@ const Wrapper = styled.div`
   `};
   ${media.phone`
     margin-top: 2.5rem;
-  `}
-
+  `};
 `
 Wrapper.propTypes = {
   set: PropTypes.string.isRequired

--- a/src/layouts/components/Divider.js
+++ b/src/layouts/components/Divider.js
@@ -21,6 +21,7 @@ const Wrapper = styled.div`
     (validJustifyValues.includes(props.set) && props.set) || 'flex-end'};
   ${media.desktop`
     padding: 0.5em;
+    margin-top: 2.5rem;
   `};
   ${media.phone`
     margin-top: 2.5rem;

--- a/src/layouts/components/Hero.js
+++ b/src/layouts/components/Hero.js
@@ -189,6 +189,8 @@ const SimpleHeroTitle = HeroTitle.extend`
     padding: 0.5rem 0 1.4rem 0;
   `} ${media.phone`
     font-size: 3.4rem;
+    margin-bottom: 0;
+    padding-bottom: 0.5rem;
   `};
 `
 

--- a/src/layouts/components/Hero.js
+++ b/src/layouts/components/Hero.js
@@ -204,6 +204,15 @@ const SimpleHeroP = StyledP.extend`
 
 const ButtonContainer = styled.div`
   grid-column: 5 / span 4;
+  ${media.desktop`
+    button {
+      padding: 0.75rem 1.2rem;
+
+    }
+  `}
+  ${media.phone`
+    margin-top: 1rem;
+  `}
 `
 
 const HeroButton = ButtonBig.extend`

--- a/src/layouts/components/Hero.js
+++ b/src/layouts/components/Hero.js
@@ -209,10 +209,9 @@ const ButtonContainer = styled.div`
       padding: 0.75rem 1.2rem;
 
     }
-  `}
-  ${media.phone`
+  `} ${media.phone`
     margin-top: 1rem;
-  `}
+  `};
 `
 
 const HeroButton = ButtonBig.extend`

--- a/src/layouts/components/Hero.js
+++ b/src/layouts/components/Hero.js
@@ -246,12 +246,14 @@ const StyledHero = styled.div`
     width: 100%;
     display: flex;
     flex-direction: column;
+    margin-bottom: 1.5rem;
   `} ${media.phone`
     background: ${props =>
       props.bg === 'main'
         ? `url(${BGmob})`
         : props => props.theme.secondary.green};
     background-size: 100% 100%;
+    margin-bottom: 1rem;
   `};
 `
 

--- a/src/layouts/components/Hero.js
+++ b/src/layouts/components/Hero.js
@@ -164,7 +164,7 @@ const StyledSimpleHero = StyledMainHero.extend`
     padding: 0rem;
   `} ${media.phone`
     grid-column: none;
-    min-height: 220px;
+    min-height: 200px;
     height: auto;
     margin-bottom: 1rem;
   `};

--- a/src/layouts/components/ProjectCard.js
+++ b/src/layouts/components/ProjectCard.js
@@ -2,7 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { StyledH3, StyledP, StyledUl, StyledLi, media } from '../../theme/globalStyle'
+import {
+  StyledH3,
+  StyledP,
+  StyledUl,
+  StyledLi,
+  media
+} from '../../theme/globalStyle'
 
 import faker from 'faker'
 
@@ -17,10 +23,9 @@ const Wrapper = styled.div`
 
   ${media.tablet`
     flex: 1 0 8em;
-  `}
-  ${media.phone`
+  `} ${media.phone`
     flex: 1 1 10em;
-  `}
+  `};
 `
 
 const Image = styled.img`
@@ -30,7 +35,7 @@ const Image = styled.img`
   margin: 1rem 0.5rem;
   ${media.phone`
     width: 65%;
-  `}
+  `};
 `
 
 const ProjectTitle = StyledH3.extend`
@@ -43,17 +48,14 @@ const ProjectTitle = StyledH3.extend`
   display: ${props => props.visibility || 'block'};
   ${media.giant`
     font-size: 1.25rem;
-  `}
-  ${media.desktop`
+  `} ${media.desktop`
     font-size: 1.125rem;
-  `}
-  ${media.tablet`
+  `} ${media.tablet`
     min-height: 1.5em;
     font-size: 1.125rem;
-  `}
-  ${media.phone`
+  `} ${media.phone`
     font-size: 1.2rem;
-  `}
+  `};
 `
 
 const ProjectP = StyledP.extend`
@@ -63,11 +65,10 @@ const ProjectP = StyledP.extend`
   font-size: 1.125rem;
   ${media.desktop`
     font-size: 1rem;
-  `}
-  ${media.phone`
+  `} ${media.phone`
     font-size: 1.125rem;
     padding: 0.5rem 0.5rem 1.2rem 0.5rem;
-  `}
+  `};
 `
 
 const CardUl = StyledUl.extend`
@@ -78,10 +79,9 @@ const CardUl = StyledUl.extend`
   ${media.tablet`
     align-self: flex-start;
     margin-left: 10%;
-  `}
-  ${media.phone`
+  `} ${media.phone`
     margin-left: 15%;
-  `}
+  `};
 `
 
 const CardLi = StyledLi.extend`
@@ -89,7 +89,7 @@ const CardLi = StyledLi.extend`
   font-size: 1.125rem;
   ${media.desktop`
     font-size: 1rem;
-  `}
+  `};
 `
 
 const ProjectLi = () => (

--- a/src/layouts/components/ProjectCard.js
+++ b/src/layouts/components/ProjectCard.js
@@ -2,64 +2,87 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { StyledH3, StyledP, StyledUl, StyledLi } from '../../theme/globalStyle'
+import { StyledH3, StyledP, StyledUl, StyledLi, media } from '../../theme/globalStyle'
 
 import faker from 'faker'
 
 const Wrapper = styled.div`
-  width: ${props => props.width || 'auto'};
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: minmax(100px, auto);
-  grid-template-areas:
-    'img'
-    'text';
-  align-content: start;
+  flex: 1 0 10em;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
   background: ${props => props.theme.primary.light};
   border-radius: 4px;
+
+  ${media.tablet`
+    flex: 1 0 8em;
+  `}
+  ${media.phone`
+    flex: 1 1 10em;
+  `}
 `
 
 const Image = styled.img`
-  grid-area: img;
-  justify-self: center;
   border-radius: 2px;
   display: block;
   width: 80%;
   margin: 1rem 0.5rem;
-`
-
-const Text = styled.div`
-  grid-area: text;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto;
-  padding: 0.5rem;
-  margin: 0.3rem;
+  ${media.phone`
+    width: 65%;
+  `}
 `
 
 const ProjectTitle = StyledH3.extend`
+  min-height: 3.5em;
   color: ${props => props.theme.white};
   margin: 0.5rem;
-  padding: 0;
+  margin-bottom: auto;
+  padding: 0 0.5rem;
   text-align: center;
   display: ${props => props.visibility || 'block'};
+  ${media.giant`
+    font-size: 1.25rem;
+  `}
+  ${media.desktop`
+    font-size: 1.125rem;
+  `}
+  ${media.tablet`
+    min-height: 1.5em;
+    font-size: 1.125rem;
+  `}
+  ${media.phone`
+    font-size: 1.2rem;
+  `}
 `
 
 const ProjectP = StyledP.extend`
   color: ${props => props.theme.white};
-  margin: 0.5rem;
-  padding: 0;
+  margin-top: auto;
+  padding: 0 0.5rem 0.8rem 0.5rem;
+  font-size: 1.125rem;
+  ${media.desktop`
+    font-size: 1rem;
+  `}
+  ${media.phone`
+    font-size: 1.125rem;
+    padding: 0.5rem 0.5rem 1.2rem 0.5rem;
+  `}
 `
 
 const CardUl = StyledUl.extend`
   color: ${props => props.theme.white};
   list-style-type: circle;
   margin: 1rem;
-  padding: 0;
+  padding: 0 0.5rem;
 `
 
 const CardLi = StyledLi.extend`
   padding: 0;
+  font-size: 1.125rem;
+  ${media.desktop`
+    font-size: 1rem;
+  `}
 `
 
 const ProjectLi = () => (
@@ -75,23 +98,20 @@ class ProjectCard extends React.Component {
     return (
       <Wrapper>
         <Image src={this.props.img} />
-        <Text>
-          <ProjectTitle visibility={this.props.heading}>
-            {this.props.title}
-          </ProjectTitle>
-          {this.props.type === 'list' ? (
-            <ProjectLi />
-          ) : (
-            <ProjectP>{this.props.text}</ProjectP>
-          )}
-        </Text>
+        <ProjectTitle visibility={this.props.heading}>
+          {this.props.title}
+        </ProjectTitle>
+        {this.props.type === 'list' ? (
+          <ProjectLi />
+        ) : (
+          <ProjectP>{this.props.text}</ProjectP>
+        )}
       </Wrapper>
     )
   }
 }
 
 ProjectCard.propTypes = {
-  width: PropTypes.string,
   title: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   img: PropTypes.string,

--- a/src/layouts/components/ProjectCard.js
+++ b/src/layouts/components/ProjectCard.js
@@ -75,6 +75,13 @@ const CardUl = StyledUl.extend`
   list-style-type: circle;
   margin: 1rem;
   padding: 0 0.5rem;
+  ${media.tablet`
+    align-self: flex-start;
+    margin-left: 10%;
+  `}
+  ${media.phone`
+    margin-left: 15%;
+  `}
 `
 
 const CardLi = StyledLi.extend`

--- a/src/layouts/components/SectionTitle.js
+++ b/src/layouts/components/SectionTitle.js
@@ -6,8 +6,7 @@ const SectionTitle = StyledH2.extend`
   color: ${props => props.theme.primary.light};
   ${media.desktop`
     margin: 1.5rem 0;
-  `}
-  ${media.tablet`
+  `} ${media.tablet`
     font-size: 1.8rem;
     margin: 0.5rem 0;
   `} ${media.phone`

--- a/src/layouts/components/SectionTitle.js
+++ b/src/layouts/components/SectionTitle.js
@@ -4,11 +4,15 @@ const SectionTitle = StyledH2.extend`
   text-align: center;
   text-transform: uppercase;
   color: ${props => props.theme.primary.light};
+  ${media.desktop`
+    margin: 1.5rem 0;
+  `}
   ${media.tablet`
     font-size: 1.8rem;
+    margin: 0.5rem 0;
   `} ${media.phone`
     font-size: 1.46rem;
-    padding: 1.4rem; 
+    padding: 1.4rem;
   `};
 `
 export default SectionTitle

--- a/src/layouts/components/SectionTitle.js
+++ b/src/layouts/components/SectionTitle.js
@@ -8,6 +8,7 @@ const SectionTitle = StyledH2.extend`
     font-size: 1.8rem;
   `} ${media.phone`
     font-size: 1.46rem;
+    padding: 1.4rem; 
   `};
 `
 export default SectionTitle

--- a/src/layouts/components/StoryCard.js
+++ b/src/layouts/components/StoryCard.js
@@ -17,10 +17,9 @@ const Wrapper = styled.div`
     'img img img'
     'text text text';
     //grid-template-rows: 30% minmax(17em, auto);
-  `}
-  ${media.phone`
+  `} ${media.phone`
     margin: 0;
-  `}
+  `};
 `
 const Image = styled.img`
   grid-area: img;
@@ -33,7 +32,7 @@ const Image = styled.img`
   ${media.desktop`
     width: 6rem;
     height: 6rem;
-  `}
+  `};
 `
 
 const Text = styled.div`
@@ -46,16 +45,14 @@ const Text = styled.div`
   align-items: center;
   ${media.desktop`
     justify-content: space-between;
-  `}
-  ${media.tablet`
+  `} ${media.tablet`
     justify-content: space-between;
     padding-top: 0;
     margin-top: 0.5rem;
-  `}
-  ${media.phone`
+  `} ${media.phone`
     padding: 0 0.3rem;
     margin-top: 0;
-  `}
+  `};
 `
 
 const StoryTitle = StyledH3.extend`
@@ -65,11 +62,10 @@ const StoryTitle = StyledH3.extend`
   padding: 0rem;
   ${media.desktop`
     font-size: 1.2rem;
-  `}
-  ${media.phone`
+  `} ${media.phone`
     padding: 0.5rem;
     font-size: 1.25rem;
-  `}
+  `};
 `
 
 const StoryText = StyledP.extend`
@@ -79,17 +75,14 @@ const StoryText = StyledP.extend`
   padding: 0;
   ${media.giant`
     font-size: 1.1rem;
-  `}
-  ${media.desktop`
+  `} ${media.desktop`
     font-size: 1rem;
-  `}
-  ${media.tablet`
-  `}
-  ${media.phone`
+  `} ${media.tablet`
+  `} ${media.phone`
     margin-top:0;
     padding: 0 0.25rem;
     font-size: 1.05rem;
-  `}
+  `};
 `
 
 const ButtonContainer = styled.div`
@@ -99,13 +92,12 @@ const ButtonContainer = styled.div`
   margin-top: auto;
   ${media.desktop`
     margin-bottom: 1rem;
-  `}
-  ${media.tablet`
+  `} ${media.tablet`
     margin-bottom: 0.5rem;
     & > button {
       padding: 0.75rem 1.5rem;
     }
-  `}
+  `};
 `
 
 class StoryCard extends React.Component {

--- a/src/layouts/components/StoryCard.js
+++ b/src/layouts/components/StoryCard.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { StyledH3, StyledP } from '../../theme/globalStyle'
+import { StyledH3, StyledP, media } from '../../theme/globalStyle'
 import { ButtonBig } from '../components/Button'
 
 const Wrapper = styled.div`
@@ -12,34 +12,16 @@ const Wrapper = styled.div`
   grid-template-areas: 'img text text';
   background: ${props => props.theme.primary.light};
   border-radius: 4px;
+  ${media.tablet`
+    grid-template-areas:
+    'img img img'
+    'text text text';
+    //grid-template-rows: 30% minmax(17em, auto);
+  `}
+  ${media.phone`
+    margin: 0;
+  `}
 `
-
-const StoryTitle = StyledH3.extend`
-  color: ${props => props.theme.white};
-  margin: 0.5rem 0;
-  padding: 0rem;
-  grid-column: 1 / span 4;
-  grid-row: 1 / span 1;
-`
-
-const StoryText = StyledP.extend`
-  color: ${props => props.theme.white};
-  margin: 0.2rem 0.2rem 1rem 0.2rem;
-  padding: 0rem;
-  grid-column: 1 / span 4;
-  grid-row: 2 / span 2;
-`
-
-const Text = styled.div`
-  grid-area: text;
-  padding: 0.5rem;
-  margin: 0.5rem;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: repeat(4, 1fr);
-  align-content: start;
-`
-
 const Image = styled.img`
   grid-area: img;
   justify-self: center;
@@ -48,10 +30,82 @@ const Image = styled.img`
   border: 1px solid #000;
   width: 6.25rem;
   height: 6.25rem;
+  ${media.desktop`
+    width: 6rem;
+    height: 6rem;
+  `}
 `
+
+const Text = styled.div`
+  grid-area: text;
+  padding: 0.5rem;
+  margin: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  ${media.desktop`
+    justify-content: space-between;
+  `}
+  ${media.tablet`
+    justify-content: space-between;
+    padding-top: 0;
+    margin-top: 0.5rem;
+  `}
+  ${media.phone`
+    padding: 0 0.3rem;
+    margin-top: 0;
+  `}
+`
+
+const StoryTitle = StyledH3.extend`
+  grid-column: 1 / span 4;
+  color: ${props => props.theme.white};
+  margin: 0.5rem 0;
+  padding: 0rem;
+  ${media.desktop`
+    font-size: 1.2rem;
+  `}
+  ${media.phone`
+    padding: 0.5rem;
+    font-size: 1.25rem;
+  `}
+`
+
+const StoryText = StyledP.extend`
+  grid-column: 1 / span 4;
+  color: ${props => props.theme.white};
+  margin: 0.2rem 0.2rem 1.2rem 0.2rem;
+  padding: 0;
+  ${media.giant`
+    font-size: 1.1rem;
+  `}
+  ${media.desktop`
+    font-size: 1rem;
+  `}
+  ${media.tablet`
+  `}
+  ${media.phone`
+    margin-top:0;
+    padding: 0 0.25rem;
+    font-size: 1.05rem;
+  `}
+`
+
 const ButtonContainer = styled.div`
-  grid-column: 2 / span 2;
-  grid-row: 4 / span 1;
+  grid-column: 1 / span 4;
+  align-self: center;
+  justify-self: center;
+  margin-top: auto;
+  ${media.desktop`
+    margin-bottom: 1rem;
+  `}
+  ${media.tablet`
+    margin-bottom: 0.5rem;
+    & > button {
+      padding: 0.75rem 1.5rem;
+    }
+  `}
 `
 
 class StoryCard extends React.Component {

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -15,7 +15,9 @@ const EventsPage = () => (
     <Hero type="events" />
     <SectionTitle>featured events</SectionTitle>
 
-    <CardContainer cols={4} cards={4}>{addCards(4, 'project', 'list')}</CardContainer>
+    <CardContainer cols={4} cards={4}>
+      {addCards(4, 'project', 'list')}
+    </CardContainer>
   </div>
 )
 

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -15,7 +15,7 @@ const EventsPage = () => (
     <Hero type="events" />
     <SectionTitle>featured events</SectionTitle>
 
-    <CardContainer cols={4}>{addCards(4, 'project', 'list')}</CardContainer>
+    <CardContainer cols={4} cards={4}>{addCards(4, 'project', 'list')}</CardContainer>
   </div>
 )
 

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -50,11 +50,15 @@ const LearnPage = props => (
     <Hero type="learn" />
     <SectionTitle>featured courses</SectionTitle>
 
-    <CardContainer cols={5} cards={6}>{addCards(6, 'project')}</CardContainer>
+    <CardContainer cols={5} cards={6}>
+      {addCards(6, 'project')}
+    </CardContainer>
 
     <SectionTitle>coding interviews</SectionTitle>
 
-    <CardContainer cols={5} cards={6}>{addCards(6, 'project')}</CardContainer>
+    <CardContainer cols={5} cards={6}>
+      {addCards(6, 'project')}
+    </CardContainer>
 
     <Divider justify={'space-around'} background={props.theme.secondary.green}>
       <IconWrapper>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -50,11 +50,11 @@ const LearnPage = props => (
     <Hero type="learn" />
     <SectionTitle>featured courses</SectionTitle>
 
-    <CardContainer cols={5}>{addCards(5, 'project')}</CardContainer>
+    <CardContainer cols={5} cards={6}>{addCards(6, 'project')}</CardContainer>
 
     <SectionTitle>coding interviews</SectionTitle>
 
-    <CardContainer cols={5}>{addCards(5, 'project')}</CardContainer>
+    <CardContainer cols={5} cards={6}>{addCards(6, 'project')}</CardContainer>
 
     <Divider justify={'space-around'} background={props.theme.secondary.green}>
       <IconWrapper>

--- a/src/pages/stories.js
+++ b/src/pages/stories.js
@@ -17,7 +17,9 @@ const StoriesPage = () => (
     <Hero type="stories" />
     <SectionTitle>Stories Page</SectionTitle>
 
-    <CardContainer cols={2} story={true}>{addCards(4, 'story')}</CardContainer>
+    <CardContainer cols={2} story={true}>
+      {addCards(4, 'story')}
+    </CardContainer>
     <div style={{ display: 'flex', justifyContent: 'center', padding: '4px' }}>
       <Pagination pageNum={5} />
     </div>

--- a/src/pages/stories.js
+++ b/src/pages/stories.js
@@ -17,7 +17,7 @@ const StoriesPage = () => (
     <Hero type="stories" />
     <SectionTitle>Stories Page</SectionTitle>
 
-    <CardContainer cols={2}>{addCards(4, 'story')}</CardContainer>
+    <CardContainer cols={2} story={true}>{addCards(4, 'story')}</CardContainer>
     <div style={{ display: 'flex', justifyContent: 'center', padding: '4px' }}>
       <Pagination pageNum={5} />
     </div>

--- a/src/pages/support.js
+++ b/src/pages/support.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Hero from '../layouts/components/Hero'
 
-import { StyledH2, StyledP } from '../theme/globalStyle'
+import { StyledH2, StyledP, media } from '../theme/globalStyle'
 import CardContainer from '../layouts/components/CardContainer'
 import { addCards } from '../layouts/utils/helpers'
 import Divider from '../layouts/components/Divider'
@@ -17,6 +17,10 @@ const SectionTitle = StyledH2.extend`
 `
 const SectionP = StyledP.extend`
   color: ${props => props.theme.text};
+  ${media.tablet`
+    font-size: 1rem;
+    padding: 0.5rem;
+  `}
 `
 
 const SupportPage = () => (
@@ -29,7 +33,7 @@ const SupportPage = () => (
 
     <SectionTitle>featured projects</SectionTitle>
 
-    <CardContainer cols={5}>{addCards(5, 'project')}</CardContainer>
+    <CardContainer cols={5} cards={6}>{addCards(6, 'project')}</CardContainer>
 
     <SectionTitle>search &#38; filter here</SectionTitle>
 

--- a/src/pages/support.js
+++ b/src/pages/support.js
@@ -20,7 +20,7 @@ const SectionP = StyledP.extend`
   ${media.tablet`
     font-size: 1rem;
     padding: 0.5rem;
-  `}
+  `};
 `
 
 const SupportPage = () => (
@@ -33,7 +33,9 @@ const SupportPage = () => (
 
     <SectionTitle>featured projects</SectionTitle>
 
-    <CardContainer cols={5} cards={6}>{addCards(6, 'project')}</CardContainer>
+    <CardContainer cols={5} cards={6}>
+      {addCards(6, 'project')}
+    </CardContainer>
 
     <SectionTitle>search &#38; filter here</SectionTitle>
 


### PR DESCRIPTION
Sorry guys, it has quite a lot of changes. :package: 

Main **goal** was to make all cards **responsive** with **minimum number of changes** to the components structure.

I updated `Cards` and `CardsContainer` on every page which had it. So that, If you have started **Support** and **Stories** Pages,  responsive `Cards` are already there.

If you are curious about props of `CardContainer`
```jsx
<CardContainer cols={5} cards={6}>
      {addCards(6, 'project')}
    </CardContainer>

```
or
```jsx
<CardContainer cols={5}>{addCards(10, 'project')}</CardContainer>
```
or 
```jsx
<CardContainer cols={2} story={true}>
      {addCards(4, 'story')}
    </CardContainer>
```
and its usage pattern, there is a comment about it in `CardContainer.js`

P.S.
closes #168 
closes #164  
 